### PR TITLE
v0.3.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,8 +29,20 @@ jobs:
 
       - name: Install dependencies
         run: bun install
+
+      - name: Check GA var
+        run: |
+          echo "GA ID: ${VITE_GA_MEASUREMENT_ID}"
+          test -n "$VITE_GA_MEASUREMENT_ID" || (echo "Missing GA ID" && exit 1)
+
       - name: Build
         run: bun run build
+        env:
+          VITE_GA_MEASUREMENT_ID: ${{ vars.VITE_GA_MEASUREMENT_ID }}
+
+      - name: Assert GA ID baked into dist
+        run: |
+          grep -R "$VITE_GA_MEASUREMENT_ID" dist || (echo "GA ID not found in dist" && exit 1)
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
This pull request adds checks to the deployment workflow to ensure that the Google Analytics (GA) Measurement ID is set and correctly baked into the production build. These changes help prevent deployments without proper analytics configuration.

Deployment workflow improvements:

* Added a step to verify that the `VITE_GA_MEASUREMENT_ID` environment variable is set before building, failing the workflow if it is missing. (.github/workflows/deploy.yml)
* Updated the build step to explicitly pass the `VITE_GA_MEASUREMENT_ID` environment variable. (.github/workflows/deploy.yml)
* Added a post-build check to assert that the GA Measurement ID is present in the built `dist` directory, failing if it is missing. (.github/workflows/deploy.yml)